### PR TITLE
Auth refactor 7: reinforce logic to ask for user name if it is null

### DIFF
--- a/app/(routes)/confirm/page.tsx
+++ b/app/(routes)/confirm/page.tsx
@@ -17,12 +17,11 @@ export default function ConfirmSignIn() {
   useEffect(() => {
     const handleSignIn = async () => {
       const emailLink = window.location.href;
-
       try {
         const success = await completeSignIn(emailLink);
         if (success && user?.displayName === null) {
           setUpdateName(true);
-        } else if (success) {
+        } else if (success && user?.displayName !== null) {
           router.push("/exam");
         } else {
           setError("Sign-in failed. Please try again.");

--- a/app/(routes)/login/page.tsx
+++ b/app/(routes)/login/page.tsx
@@ -1,7 +1,14 @@
 "use client";
 import { sendSignInEmail } from "@/firebase/authAPI";
 import { useAuthContext } from "@/firebase/authContext";
-import { Box, Button, Container, TextField, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  Container,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
@@ -39,12 +46,12 @@ export default function Login() {
   };
 
   return (
-    <Container
-      component="main"
+    <Stack
+      alignItems={"center"}
       sx={{ fontFamily: "Monospace", paddingTop: "4rem" }}
     >
       {message === "" && error === "" && (
-        <Box>
+        <Box width={"575px"}>
           <Typography variant="body1" align="center">
             Please enter your email address to receive a sign-in link.
           </Typography>
@@ -95,6 +102,6 @@ export default function Login() {
           {error}
         </Typography>
       )}
-    </Container>
+    </Stack>
   );
 }


### PR DESCRIPTION
- Add else if success && user?.displayName !== null to handleSignIn useEffect in confirm page, hopefully to prevent it from automatically routing to the exam page.
- Slight CSS changes to login "enter email" section.