### PR TITLE
Seventh chords Identify - bass clef

### DIFF
--- a/VexFlow-license.txt
+++ b/VexFlow-license.txt
@@ -1,0 +1,22 @@
+VexFlow - A JavaScript library for rendering music notation.
+
+Copyright (c) 2023-present VexFlow contributors (see AUTHORS.md).
+Copyright (c) 2010-2022 Mohit Muthanna Cheppudira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -634,7 +634,7 @@ export default function ExamHomePage() {
             </Stack>
           </main>
         )}
-        {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
+        {/* {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
           viewState !== VIEW_STATES.START_TEST && (
             <Stack spacing={4}>
               <Button onClick={incrementViewState}>
@@ -649,7 +649,7 @@ export default function ExamHomePage() {
                 <Typography>{"Go to Progressions"}</Typography>
               </Button>
             </Stack>
-          )}
+          )} */}
       </Stack>
     </Box>
   );

--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -634,7 +634,7 @@ export default function ExamHomePage() {
             </Stack>
           </main>
         )}
-        {/* {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
+        {viewState !== VIEW_STATES.SUBMIT_AND_EXIT &&
           viewState !== VIEW_STATES.START_TEST && (
             <Stack spacing={4}>
               <Button onClick={incrementViewState}>
@@ -649,7 +649,7 @@ export default function ExamHomePage() {
                 <Typography>{"Go to Progressions"}</Typography>
               </Button>
             </Stack>
-          )} */}
+          )}
       </Stack>
     </Box>
   );

--- a/app/components/ExamPages/ChordsIdentify.tsx
+++ b/app/components/ExamPages/ChordsIdentify.tsx
@@ -2,9 +2,13 @@
 import { InputData, UserDataProps } from "@/app/lib/typesAndInterfaces";
 import { Box, Container, Grid, Typography } from "@mui/material";
 import { useRef } from "react";
-import seventhChords from "../../lib/data/seventhChords";
+import {
+  seventhChordsTreble,
+  seventhChordsBass,
+} from "../../lib/data/seventhChords";
 import CardFooter from "../CardFooter";
 import IdentifyNotation from "../IdentifyNotation";
+import { useClef } from "../../context/ClefContext";
 
 export default function ChordsIdentification({
   currentUserData,
@@ -17,6 +21,11 @@ export default function ChordsIdentification({
   function handleChords(input: InputData) {
     setCurrentUserData({ ...currentUserData, chords: input });
   }
+
+  const { chosenClef } = useClef();
+
+  let seventhChords =
+    chosenClef === "treble" ? seventhChordsTreble : seventhChordsBass;
 
   const boxStyle = {
     display: "flex",

--- a/app/lib/data/seventhChords.js
+++ b/app/lib/data/seventhChords.js
@@ -1,4 +1,4 @@
-const seventhChords = [
+export const seventhChordsTreble = [
   {
     keys: ["e#/4", "g#/4", "b/4", "d/5"],
     duration: "w",
@@ -29,4 +29,40 @@ const seventhChords = [
   },
 ];
 
-export default seventhChords;
+export const seventhChordsBass = [
+  {
+    keys: ["e#/2", "g#/2", "b/2", "d/3"],
+    duration: "w",
+    clef: "bass",
+  },
+  {
+    keys: ["f/2", "a/2", "c/3", "e/3"],
+    duration: "w",
+    clef: "bass",
+  },
+  {
+    keys: ["g/2", "bb/2", "d/3", "f#/3"],
+    duration: "w",
+    clef: "bass",
+  },
+  {
+    keys: ["b/2", "d#/3", "f#/3", "a/3"],
+    duration: "w",
+    clef: "bass",
+  },
+  {
+    keys: ["f#/2", "a/2", "c/3", "e/3"],
+    duration: "w",
+    clef: "bass",
+  },
+  {
+    keys: ["ab/2", "cb/3", "eb/3", "gb/3"],
+    duration: "w",
+    clef: "bass",
+  },
+  {
+    keys: ["d/2", "f#/2", "a#/2", "c/3"],
+    duration: "w",
+    clef: "bass",
+  },
+];


### PR DESCRIPTION
- Add bass clef octave version of seventh chords to lib/data/seventhChords.js with the clef property as "bass".
- Add logic to ChordsIdentify to determine whether to pass treble or bass seventh chords.
- Add VexFlow license to the project with a txt file.