### PR TITLE
LimitScalesTo7Notes

### DIFF
--- a/app/(routes)/exam/page.tsx
+++ b/app/(routes)/exam/page.tsx
@@ -639,14 +639,14 @@ export default function ExamHomePage() {
               <Button onClick={incrementViewState}>
                 <Typography variant="h4">{">"}</Typography>
               </Button>
-              <Button onClick={() => setViewState(VIEW_STATES.TRIADS_NOTATE1)}>
+              {/* <Button onClick={() => setViewState(VIEW_STATES.TRIADS_NOTATE1)}>
                 <Typography>{"Go to Triads"}</Typography>
               </Button>
               <Button
                 onClick={() => setViewState(VIEW_STATES.WRITE_PROGRESSIONS)}
               >
                 <Typography>{"Go to Progressions"}</Typography>
-              </Button>
+              </Button> */}
             </Stack>
           )}
       </Stack>

--- a/app/components/NotateChord.tsx
+++ b/app/components/NotateChord.tsx
@@ -15,6 +15,7 @@ import VexFlow from "vexflow";
 import CheckIfNoteFound from "../components/CheckIfNoteFound";
 import CheckNumBeatsInMeasure from "../components/CheckNumBeatsInMeasure";
 import { useClef } from "../context/ClefContext";
+import { useInitialRun } from "../context/initialNotesAndCoordsContext";
 import { modifyChordsActionTypes } from "../lib/actionTypes";
 import { buttonGroup } from "../lib/buttonsAndButtonGroups";
 import calculateNotesAndCoordinates from "../lib/calculateNotesAndCoordinates";
@@ -23,7 +24,6 @@ import {
   trebleClefNotesArray,
 } from "../lib/data/noteArray";
 import { staveData } from "../lib/data/stavesData";
-import { findBarIndex } from "../lib/findBar";
 import getUserClickInfo from "../lib/getUserClickInfo";
 import { handleChordInteraction } from "../lib/handleChordInteraction";
 import {
@@ -32,7 +32,7 @@ import {
   initialNotesAndCoordsState,
 } from "../lib/initialStates";
 import { initializeRenderer } from "../lib/initializeRenderer";
-import { chordReducer } from "../lib/reducer";
+import { reducer } from "../lib/reducer";
 import { setupRendererAndDrawChords } from "../lib/setUpRendererAndDrawChords";
 import {
   Chord,
@@ -40,7 +40,6 @@ import {
   StaveType,
 } from "../lib/typesAndInterfaces";
 import CustomButton from "./CustomButton";
-import { useInitialRun } from "../context/initialNotesAndCoordsContext";
 const { Renderer } = VexFlow.Flow;
 
 //dim is shit-option-8
@@ -61,10 +60,7 @@ const NotateChord = ({
   const rendererRef = useRef<InstanceType<typeof Renderer> | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
   const [staves, setStaves] = useState<StaveType[]>([]);
-  const [state, dispatch] = useReducer(
-    chordReducer,
-    chordInteractionInitialState
-  );
+  const [state, dispatch] = useReducer(reducer, chordInteractionInitialState);
   const [barIndex, setBarIndex] = useState<number>(0);
   const [chordData, setChordData] = useState<Chord>(initialChordData);
   const { chosenClef } = useClef();

--- a/app/components/NotateKeySignature.tsx
+++ b/app/components/NotateKeySignature.tsx
@@ -26,7 +26,7 @@ import {
 } from "../lib/initialStates";
 import { initializeRenderer } from "../lib/initializeRenderer";
 import isClickWithinStaveBounds from "../lib/isClickWithinStaveBounds";
-import { keySigReducer } from "../lib/reducer";
+import { reducer } from "../lib/reducer";
 import { setupRendererAndDrawGlyphs } from "../lib/setUpRendererAndDrawGlyphs";
 import {
   GlyphProps,
@@ -34,7 +34,6 @@ import {
   StaveType,
 } from "../lib/typesAndInterfaces";
 import CustomButton from "./CustomButton";
-import { Button, Stack, Typography } from "@mui/material";
 
 const VF = VexFlow.Flow;
 const { Renderer } = VF;
@@ -57,7 +56,7 @@ const NotateKeySignature = ({
   const [open, setOpen] = useState(false);
   const { chosenClef } = useClef();
   const [snackbarMessage, setSnackbarMessage] = useState("");
-  const [state, dispatch] = useReducer(keySigReducer, keySigInitialState);
+  const [state, dispatch] = useReducer(reducer, keySigInitialState);
   const [keySig, setKeySig] = useState<string[]>([]);
   const [notesAndCoordinates, setNotesAndCoordinates] = useState<
     NotesAndCoordinatesData[]

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -145,11 +145,16 @@ const NotateScale = ({
           userClickY >= yCoordinateMin && userClickY <= yCoordinateMax
       );
 
-      if (foundNoteData)
+      if (foundNoteData) {
         foundNoteData = {
           ...foundNoteData,
-          userClickY: userClickY,
+          userClickY,
         };
+      } else {
+        setOpen(true);
+        setMessage(errorMessages.noNoteFound);
+        return;
+      }
 
       const barIndex = findBarIndex(staves, userClickX);
 

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -110,7 +110,7 @@ const NotateScale = ({
         true
       );
     }
-  }, [scaleDataMatrix]);
+  }, [scaleDataMatrix, state]);
 
   const eraseMeasures = () => {
     setScaleDataMatrix([[]]);
@@ -136,7 +136,6 @@ const NotateScale = ({
         container,
         staves[0]
       );
-
       let foundNoteData = notesAndCoordinates.find(
         ({ yCoordinateMin, yCoordinateMax }) =>
           userClickY >= yCoordinateMin && userClickY <= yCoordinateMax
@@ -169,7 +168,6 @@ const NotateScale = ({
             : 0,
         })
       );
-
       const {
         scaleDataMatrix: newScaleDataMatrix,
         notesAndCoordinates: newNotesAndCoordinates,

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -13,11 +13,11 @@ import React, {
   useState,
 } from "react";
 import VexFlow from "vexflow";
-import SnackbarToast from "./SnackbarToast";
 import { useClef } from "../context/ClefContext";
 import { modifyNotesActionTypes } from "../lib/actionTypes";
 import { buttonGroup } from "../lib/buttonsAndButtonGroups";
 import calculateNotesAndCoordinates from "../lib/calculateNotesAndCoordinates";
+import { errorMessages } from "../lib/data/errorMessages";
 import {
   bassClefNotesArray,
   trebleClefNotesArray,
@@ -31,26 +31,19 @@ import {
   noteInteractionInitialState,
 } from "../lib/initialStates";
 import { initializeRenderer } from "../lib/initializeRenderer";
-import { errorMessages } from "../lib/data/errorMessages";
 import { scaleReducer } from "../lib/reducer";
 import { setupRendererAndDrawNotes } from "../lib/setupRendererAndDrawNotes";
 import {
-  NoteInteractionState,
   NotesAndCoordinatesData,
   ScaleData,
   StaveType,
 } from "../lib/typesAndInterfaces";
 import CustomButton from "./CustomButton";
+import SnackbarToast from "./SnackbarToast";
 
 const { Renderer } = VexFlow.Flow;
 
-const NotateScale = ({
-  scales,
-  setScales,
-}: {
-  scales: string[];
-  setScales: Dispatch<SetStateAction<Array<string>>>;
-}) => {
+const NotateScale = () => {
   const rendererRef = useRef<InstanceType<typeof Renderer> | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
   const [state, dispatch] = useReducer(
@@ -192,11 +185,6 @@ const NotateScale = ({
       );
       setNotesAndCoordinates(() => newNotesAndCoordinates);
       setScaleDataMatrix(() => newScaleDataMatrix);
-      setScales(
-        newScaleDataMatrix[0].map((scaleDataMatrix) =>
-          scaleDataMatrix.keys.join(", ")
-        )
-      );
     },
 
     [scaleDataMatrix, notesAndCoordinates, staves, chosenClef]

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -31,7 +31,7 @@ import {
   noteInteractionInitialState,
 } from "../lib/initialStates";
 import { initializeRenderer } from "../lib/initializeRenderer";
-import { scaleReducer } from "../lib/reducer";
+import { reducer } from "../lib/reducer";
 import { setupRendererAndDrawNotes } from "../lib/setupRendererAndDrawNotes";
 import {
   NotesAndCoordinatesData,
@@ -50,10 +50,7 @@ const NotateScale = ({
 }) => {
   const rendererRef = useRef<InstanceType<typeof Renderer> | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
-  const [state, dispatch] = useReducer(
-    scaleReducer,
-    noteInteractionInitialState
-  );
+  const [state, dispatch] = useReducer(reducer, noteInteractionInitialState);
   const [open, setOpen] = useState<boolean>(false);
   const [message, setMessage] = useState<string>("");
   const [notesAndCoordinates, setNotesAndCoordinates] = useState<

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -98,10 +98,6 @@ const NotateScale = ({
         true
       );
   }, []);
-  //this is the array we will use for grading
-  const scaleDataForGrading = scaleDataMatrix[0].map((scaleDataMatrix) =>
-    scaleDataMatrix.keys.join(", ")
-  );
 
   useEffect(() => {
     const newStave: StaveType[] = renderStavesAndNotes();
@@ -148,11 +144,6 @@ const NotateScale = ({
         ({ yCoordinateMin, yCoordinateMax }) =>
           userClickY >= yCoordinateMin && userClickY <= yCoordinateMax
       );
-      if (!foundNoteData) {
-        setMessage(errorMessages.noNoteFound);
-        setOpen(true);
-        return;
-      }
 
       if (foundNoteData)
         foundNoteData = {
@@ -161,12 +152,6 @@ const NotateScale = ({
         };
 
       const barIndex = findBarIndex(staves, userClickX);
-
-      if (scaleDataForGrading.length >= 7) {
-        setMessage(errorMessages.tooManyNotesInMeasure);
-        setOpen(true);
-        return;
-      }
 
       let scaleDataMatrixCopy = scaleDataMatrix.map((scaleData) => [
         ...scaleData,
@@ -195,7 +180,10 @@ const NotateScale = ({
         userClickX,
         userClickY,
         barIndex,
-        chosenClef
+        chosenClef,
+        setMessage,
+        setOpen,
+        errorMessages
       );
       setNotesAndCoordinates(() => newNotesAndCoordinates);
       setScaleDataMatrix(() => newScaleDataMatrix);
@@ -205,6 +193,7 @@ const NotateScale = ({
         )
       );
     },
+
     [scaleDataMatrix, notesAndCoordinates, staves, chosenClef]
   );
 

--- a/app/components/NotateScale.tsx
+++ b/app/components/NotateScale.tsx
@@ -43,7 +43,11 @@ import SnackbarToast from "./SnackbarToast";
 
 const { Renderer } = VexFlow.Flow;
 
-const NotateScale = () => {
+const NotateScale = ({
+  setScales,
+}: {
+  setScales: Dispatch<SetStateAction<Array<string>>>;
+}) => {
   const rendererRef = useRef<InstanceType<typeof Renderer> | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
   const [state, dispatch] = useReducer(
@@ -185,6 +189,11 @@ const NotateScale = () => {
       );
       setNotesAndCoordinates(() => newNotesAndCoordinates);
       setScaleDataMatrix(() => newScaleDataMatrix);
+      setScales(
+        newScaleDataMatrix[0].map((scaleDataMatrix) =>
+          scaleDataMatrix.keys.join(", ")
+        )
+      );
     },
 
     [scaleDataMatrix, notesAndCoordinates, staves, chosenClef]

--- a/app/lib/handleChordInteraction.ts
+++ b/app/lib/handleChordInteraction.ts
@@ -1,22 +1,21 @@
 import {
   addAccidentalToChordKeys,
   addNewNoteToChord,
-  removeAccidentalFromNotesAndCoords,
   reconstructChord,
   removeAccidentalFromChord,
+  removeAccidentalFromNotesAndCoords,
   removeNoteFromChord,
-  updateNoteWithAccidental,
 } from "@/app/lib/modifyChords";
+import { updateNotesAndCoordsWithAccidental } from "./modifyNotesAndCoordinates";
 import {
   Chord,
-  ChordInteractionState,
+  StateInteraction,
   NotesAndCoordinatesData,
 } from "./typesAndInterfaces";
-import { updateNotesAndCoordsWithAccidental } from "./modifyNotesAndCoordinates";
 
 export const handleChordInteraction = (
   notesAndCoordinates: NotesAndCoordinatesData[],
-  state: ChordInteractionState,
+  state: StateInteraction,
   foundNoteData: NotesAndCoordinatesData,
   chordData: Chord,
 

--- a/app/lib/handleKeySigInteraction.ts
+++ b/app/lib/handleKeySigInteraction.ts
@@ -10,13 +10,13 @@ import {
 } from "./modifyKeySignature";
 import {
   GlyphProps,
-  KeySigState,
   NotesAndCoordinatesData,
+  StateInteraction,
 } from "./typesAndInterfaces";
 
 export const handleKeySigInteraction = (
   notesAndCoordinates: NotesAndCoordinatesData[],
-  state: KeySigState,
+  state: StateInteraction,
   foundNoteData: NotesAndCoordinatesData,
   xClick: number,
   yClick: number,

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -14,7 +14,9 @@ import {
   NotesAndCoordinatesData,
   ScaleData,
   StaveNoteType,
+  errorMessages,
 } from "./typesAndInterfaces";
+
 const { StaveNote } = VexFlow.Flow;
 
 export const HandleScaleInteraction = (
@@ -26,8 +28,14 @@ export const HandleScaleInteraction = (
   userClickX: number,
   userClickY: number,
   barIndex: number,
-  chosenClef: string
+  chosenClef: string,
+  setMessage: (newState: React.SetStateAction<string>) => void,
+  setOpen: (newState: React.SetStateAction<boolean>) => void,
+  errorMessages: errorMessages
 ) => {
+  const scaleLength = scaleDataMatrix[0].map((scaleDataMatrix) =>
+    scaleDataMatrix.keys.join(", ")
+  );
   if (state.isSharpActive || state.isFlatActive) {
     notesAndCoordinates = updateNotesAndCoordsWithAccidental(
       state,
@@ -80,6 +88,12 @@ export const HandleScaleInteraction = (
       chosenClef
     );
     scaleDataMatrix[barIndex] = barOfScaleData;
+  } else if (!foundNoteData) {
+    setOpen(true);
+    setMessage(errorMessages.noNoteFound);
+  } else if (scaleLength.length >= 7) {
+    setOpen(true);
+    setMessage(errorMessages.tooManyNotesInMeasure);
   } else {
     const newStaveNote: StaveNoteType = new StaveNote({
       keys: [foundNoteData.note],

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -35,7 +35,7 @@ export const HandleScaleInteraction = (
 ) => {
   const scaleLength = scaleDataMatrix[0].map((scaleDataMatrix) =>
     scaleDataMatrix.keys.join(", ")
-  );
+  ).length;
   if (state.isSharpActive || state.isFlatActive) {
     notesAndCoordinates = updateNotesAndCoordsWithAccidental(
       state,
@@ -88,7 +88,7 @@ export const HandleScaleInteraction = (
       chosenClef
     );
     scaleDataMatrix[barIndex] = barOfScaleData;
-  } else if (scaleLength.length >= 7) {
+  } else if (scaleLength >= 7) {
     setOpen(true);
     setMessage(errorMessages.tooManyNotesInMeasure);
   } else {

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -88,9 +88,6 @@ export const HandleScaleInteraction = (
       chosenClef
     );
     scaleDataMatrix[barIndex] = barOfScaleData;
-  } else if (!foundNoteData) {
-    setOpen(true);
-    setMessage(errorMessages.noNoteFound);
   } else if (scaleLength.length >= 7) {
     setOpen(true);
     setMessage(errorMessages.tooManyNotesInMeasure);
@@ -110,7 +107,6 @@ export const HandleScaleInteraction = (
         userClickY,
       },
     ];
-
     scaleDataMatrix[barIndex] = newNoteObject;
   }
   return {

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -10,6 +10,8 @@ import {
   removeNoteFromScale,
 } from "./modifyScales";
 import {
+  ChordInteractionState,
+  KeySigState,
   NoteInteractionState,
   NotesAndCoordinatesData,
   ScaleData,
@@ -24,7 +26,7 @@ export const HandleScaleInteraction = (
   notesAndCoordinates: NotesAndCoordinatesData[],
   barOfScaleData: ScaleData[],
   scaleDataMatrix: ScaleData[][],
-  state: NoteInteractionState,
+  state: NoteInteractionState | ChordInteractionState | KeySigState,
   userClickX: number,
   userClickY: number,
   barIndex: number,

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -33,10 +33,8 @@ export const HandleScaleInteraction = (
   setOpen: (newState: React.SetStateAction<boolean>) => void,
   errorMessages: errorMessages
 ) => {
-  const scaleLength = scaleDataMatrix[0].map((scaleDataMatrix) =>
-    scaleDataMatrix.keys.join(", ")
-  ).length;
-  
+  const scaleLength = scaleDataMatrix[0].length;
+
   if (state.isSharpActive || state.isFlatActive) {
     notesAndCoordinates = updateNotesAndCoordsWithAccidental(
       state,

--- a/app/lib/handleScaleInteraction.ts
+++ b/app/lib/handleScaleInteraction.ts
@@ -36,6 +36,7 @@ export const HandleScaleInteraction = (
   const scaleLength = scaleDataMatrix[0].map((scaleDataMatrix) =>
     scaleDataMatrix.keys.join(", ")
   ).length;
+  
   if (state.isSharpActive || state.isFlatActive) {
     notesAndCoordinates = updateNotesAndCoordsWithAccidental(
       state,

--- a/app/lib/modifyChords.ts
+++ b/app/lib/modifyChords.ts
@@ -1,9 +1,9 @@
 import VexFlow from "vexflow";
 import {
   Chord,
-  ChordInteractionState,
   NoteStringData,
   NotesAndCoordinatesData,
+  StateInteraction,
   StaveNoteType,
 } from "./typesAndInterfaces";
 const { Accidental, StaveNote } = VexFlow.Flow;
@@ -64,7 +64,7 @@ const appendAccidentalToNote = (accidental: string, note: string) => {
 };
 
 export const updateNoteWithAccidental = (
-  state: ChordInteractionState,
+  state: StateInteraction,
   foundNoteData: NoteStringData,
   notesAndCoordinates: NotesAndCoordinatesData[]
 ) => {
@@ -82,7 +82,7 @@ export const updateNoteWithAccidental = (
 };
 
 export const addAccidentalToChordKeys = (
-  state: ChordInteractionState,
+  state: StateInteraction,
   chordData: Chord,
   foundNoteIndex: number,
   chosenClef: string

--- a/app/lib/modifyKeySignature.ts
+++ b/app/lib/modifyKeySignature.ts
@@ -1,10 +1,10 @@
 import { parseNote } from "./modifyNotesAndCoordinates";
+import { roundToNearest5 } from "./roundToNearest5";
 import {
   GlyphProps,
-  KeySigState,
   NotesAndCoordinatesData,
+  StateInteraction,
 } from "./typesAndInterfaces";
-import { roundToNearest5 } from "./roundToNearest5";
 
 const tolerance = 5;
 
@@ -28,7 +28,7 @@ export const deleteGlyphFromStave = (
 export const addGlyphs = (
   userClickX: number,
   userClickY: number,
-  state: KeySigState,
+  state: StateInteraction,
   glyphs: GlyphProps[],
   setGlyphState: (newState: React.SetStateAction<GlyphProps[]>) => void
 ) => {
@@ -49,7 +49,7 @@ export const addGlyphs = (
 
 export const updateKeySigArrayForGrading = (
   foundNoteData: NotesAndCoordinatesData,
-  state: KeySigState,
+  state: StateInteraction,
   setKeySigState: (newState: React.SetStateAction<string[]>) => void
 ) => {
   const noteBase = parseNote(foundNoteData.note).noteBase;

--- a/app/lib/modifyScales.ts
+++ b/app/lib/modifyScales.ts
@@ -1,18 +1,18 @@
 import VexFlow from "vexflow";
 import { indexOfNoteToModify as indexOfNote } from "./indexOfNoteToModify";
 import {
+  appendAccidentalToNote,
+  getAccidentalType,
+  parseNote,
+  removeAccidentals,
+} from "./modifyNotesAndCoordinates";
+import {
   ModifyScaleData,
   NotesAndCoordinatesData,
   ScaleData,
+  StateInteraction,
   StaveNoteType,
 } from "./typesAndInterfaces";
-import { NoteInteractionState } from "./typesAndInterfaces";
-import {
-  getAccidentalType,
-  parseNote,
-  appendAccidentalToNote,
-  removeAccidentals,
-} from "./modifyNotesAndCoordinates";
 const { Accidental, StaveNote } = VexFlow.Flow;
 
 export const createStaveNoteFromScaleData = (
@@ -69,7 +69,7 @@ export const reconstructScale = (
 };
 
 export const addAccidentalToStaveNoteAndKeys = (
-  state: NoteInteractionState,
+  state: StateInteraction,
   scaleData: ScaleData[],
   userClickX: number,
   chosenClef: string
@@ -175,6 +175,4 @@ export const removeNoteFromScale = (
   }
 };
 
-export const errorMessages = (state: NoteInteractionState) => {
-
-}
+export const errorMessages = (state: StateInteraction) => {};

--- a/app/lib/reducer.ts
+++ b/app/lib/reducer.ts
@@ -1,37 +1,6 @@
-import {
-  ChordInteractionAction,
-  ChordInteractionState,
-  KeySigAction,
-  KeySigState,
-  NoteInteractionAction,
-  NoteInteractionState,
-} from "./typesAndInterfaces";
+import { StateInteraction, ActionType } from "./typesAndInterfaces";
 
-export const keySigReducer = (state: KeySigState, action: KeySigAction) => {
-  const newState = Object.keys(state).reduce((acc, key) => {
-    acc[key] = false;
-    return acc;
-  }, {} as typeof state);
-
-  if ("type" in action && action.type in newState) newState[action.type] = true;
-  return newState;
-};
-export const scaleReducer = (
-  state: NoteInteractionState,
-  action: NoteInteractionAction
-) => {
-  const newState = Object.keys(state).reduce((acc, key) => {
-    acc[key] = false;
-    return acc;
-  }, {} as typeof state);
-
-  if ("type" in action && action.type in newState) newState[action.type] = true;
-  return newState;
-};
-export const chordReducer = (
-  state: ChordInteractionState,
-  action: ChordInteractionAction
-) => {
+export const reducer = (state: StateInteraction, action: ActionType) => {
   const newState = Object.keys(state).reduce((acc, key) => {
     acc[key] = false;
     return acc;

--- a/app/lib/typesAndInterfaces.ts
+++ b/app/lib/typesAndInterfaces.ts
@@ -22,6 +22,16 @@ export type Chord = {
   flatIndexArray?: number[] | [];
 };
 
+export type StateInteraction =
+  | ChordInteractionState
+  | NoteInteractionState
+  | KeySigState;
+
+export type ActionType =
+  | NoteInteractionAction
+  | ChordInteractionAction
+  | KeySigAction;
+
 export type Level =
   | "advanced-theory"
   | "advanced-improvisation"

--- a/app/lib/typesAndInterfaces.ts
+++ b/app/lib/typesAndInterfaces.ts
@@ -92,6 +92,11 @@ export interface UserClickInfo {
   bottomStaveYCoord?: number;
 }
 
+export interface errorMessages {
+  tooManyNotesInMeasure: string;
+  noNoteFound: string;
+}
+
 export interface StaveNoteData {
   newStaveNote: StaveNoteType;
   staveNoteAbsoluteX: number;


### PR DESCRIPTION
Overview: 

This pull request introduces a restriction on adding notes in a scale, limiting users to a maximum of 7 notes. Additionally, it implements a warning that is triggered if the user attempts to exceed this limit or clicks outside the designated area.


Key Changes:

Enforce a 7-note limit in scales.
Implement a Snackbar warning for exceeding the note limit or clicking outside bounds.
Refactor reducer functions for improved clarity and performance.
Introduce a new type definition for stateInteraction.
Begin logic to persist data across renders

Impact: 

Enhances the user experience by providing clearer feedback and results in a more maintainable and understandable codebase.